### PR TITLE
[GATE-108] 추천일정 결과 지도 연결

### DIFF
--- a/src/interfaces/places/index.ts
+++ b/src/interfaces/places/index.ts
@@ -24,6 +24,9 @@ declare global {
   interface Window {
     kakao: {
       maps: {
+        Polyline: new (
+          options: kakao.maps.PolylineOptions
+        ) => kakao.maps.Polyline;
         load: (callback: () => void) => void;
         Map: new (container: HTMLElement, options: any) => kakao.maps.Map;
         LatLng: new (lat: number, lng: number) => kakao.maps.LatLng;
@@ -100,6 +103,23 @@ declare global {
       setContent: (content: HTMLElement | string) => void;
     }
     interface ZoomControl {}
+
+    interface PolylineOptions {
+      path: LatLng[]; // 경로 배열
+      strokeWeight?: number; // 선 두께
+      strokeColor?: string; // 선 색상
+      strokeOpacity?: number; // 선 투명도 (0~1)
+      strokeStyle?: string;
+    }
+
+    interface Polyline {
+      setMap: (map: kakao.maps.Map | null) => void; // 지도에 표시
+      setPath: (path: kakao.maps.LatLng[]) => void; // 경로 설정
+    }
+    interface LatLng {
+      getLat: () => number;
+      getLng: () => number;
+    }
   }
 }
 

--- a/src/pages/plan/components/maps/lineMap.tsx
+++ b/src/pages/plan/components/maps/lineMap.tsx
@@ -1,0 +1,108 @@
+import { useEffect, useRef } from "react";
+import ReactDOMServer from "react-dom/server";
+import LocMarkerIcons from "./locMarkerIcons";
+import colors from "../../../../styles/colors";
+
+interface Place {
+  latitude: number;
+  longitude: number;
+}
+
+interface LineMapComponentProps {
+  places: Place[];
+  centerLat: number;
+  centerLng: number;
+}
+
+export default function LineMapComponent({
+  places,
+  centerLat,
+  centerLng,
+}: LineMapComponentProps) {
+  const mapRef = useRef<HTMLDivElement | null>(null);
+
+  const getSVGComponentByIndex = (index: number) => {
+    return LocMarkerIcons[index + 1] || LocMarkerIcons[1];
+  };
+
+  useEffect(() => {
+    const initializeMap = () => {
+      const mapContainer = mapRef.current;
+      if (!mapContainer) {
+        console.error("지도 컨테이너를 찾을 수 없습니다.");
+        return;
+      }
+
+      const mapOptions = {
+        center: new window.kakao.maps.LatLng(centerLat, centerLng),
+        level: 4,
+      };
+
+      const map = new window.kakao.maps.Map(mapContainer, mapOptions);
+
+      const linePath: kakao.maps.LatLng[] = [];
+
+      places.forEach(({ latitude, longitude }, index) => {
+        const SVGComponent = getSVGComponentByIndex(index);
+        const locMarkerSVG = ReactDOMServer.renderToString(<SVGComponent />);
+
+        const icon = new window.kakao.maps.MarkerImage(
+          `data:image/svg+xml;charset=utf-8,${encodeURIComponent(
+            locMarkerSVG
+          )}`,
+          new window.kakao.maps.Size(35, 35),
+          { offset: new window.kakao.maps.Point(20, 20) }
+        );
+
+        const markerPosition = new window.kakao.maps.LatLng(
+          latitude,
+          longitude
+        );
+
+        // 마커 추가
+        new window.kakao.maps.Marker({
+          position: markerPosition,
+          map,
+          image: icon,
+        });
+
+        // 선의 경로에 좌표 추가
+        linePath.push(markerPosition);
+      });
+
+      // Polyline 생성
+      const polyline = new window.kakao.maps.Polyline({
+        path: linePath, // 좌표 배열
+        strokeWeight: 4, // 선 두께
+        strokeColor: `${colors.color.Black}`, // 선 색깔
+        strokeStyle: "shortdash", // 선 스타일
+      });
+
+      polyline.setMap(map);
+    };
+
+    const loadMapScript = () => {
+      const script = document.createElement("script");
+      script.src = `https://dapi.kakao.com/v2/maps/sdk.js?appkey=${
+        import.meta.env.VITE_KAKAO_MAP
+      }&autoload=false`;
+      script.async = true;
+      script.onload = () => {
+        if (window.kakao && window.kakao.maps) {
+          window.kakao.maps.load(initializeMap);
+        } else {
+          console.error("카카오 지도 스크립트 로드 실패");
+        }
+      };
+      document.head.appendChild(script);
+    };
+
+    if (!window.kakao || !window.kakao.maps) {
+      loadMapScript();
+    } else {
+      initializeMap();
+    }
+  }, [places, centerLat, centerLng]);
+
+  return <div ref={mapRef} style={{ width: "100%", height: "100%" }} />;
+}

--- a/src/pages/plan/recommend/index.tsx
+++ b/src/pages/plan/recommend/index.tsx
@@ -1,7 +1,9 @@
+import { useLocation } from "react-router-dom";
 import { SparklingHeart } from "../../../assets/svg";
 import { MainPinkButton, Text } from "../../../components";
 import colors from "../../../styles/colors";
 import { PlanListCard } from "../components";
+import LineMapComponent from "../components/maps/lineMap";
 import {
   bottomButtonStyle,
   contentWrapper,
@@ -19,6 +21,16 @@ export default function PlanRecommend() {
     category: "카페",
   };
 
+  const { state } = useLocation();
+  const selectItems = state?.selectItems || [];
+
+  const places = sampleSelectItems.map((item) => ({
+    placeName: item.placeName,
+    roadAddress: item.roadAddress,
+    latitude: item.latitude,
+    longitude: item.longitude,
+  }));
+
   return (
     <div css={contentWrapper}>
       <div css={wrapper}>
@@ -34,7 +46,13 @@ export default function PlanRecommend() {
             GATE가 알려준 맞춤일정으로 데이트를 즐겨보세요
           </Text>
         </div>
-        <div css={mapWrapper}>지도</div>
+        <div css={mapWrapper}>
+          <LineMapComponent
+            places={places}
+            centerLat={selectItems[0]?.latitude || 37.5665}
+            centerLng={selectItems[0]?.longitude || 126.978}
+          />
+        </div>
         <div css={listWrapper}>
           <PlanListCard sequence={1} place={place} />
           <PlanListCard sequence={1} place={place} />
@@ -63,3 +81,66 @@ export default function PlanRecommend() {
     </div>
   );
 }
+
+const sampleSelectItems = [
+  {
+    placeName: "장소 1",
+    roadAddress: "서울특별시 종로구 종로1가",
+    latitude: 37.5704,
+    longitude: 126.9768,
+  },
+  {
+    placeName: "장소 2",
+    roadAddress: "서울특별시 종로구 종로2가",
+    latitude: 37.571,
+    longitude: 126.9775,
+  },
+  {
+    placeName: "장소 3",
+    roadAddress: "서울특별시 종로구 종로3가",
+    latitude: 37.572,
+    longitude: 126.9782,
+  },
+  {
+    placeName: "장소 4",
+    roadAddress: "서울특별시 종로구 관철동",
+    latitude: 37.5708,
+    longitude: 126.9804,
+  },
+  {
+    placeName: "장소 5",
+    roadAddress: "서울특별시 종로구 청진동",
+    latitude: 37.5716,
+    longitude: 126.9798,
+  },
+  {
+    placeName: "장소 6",
+    roadAddress: "서울특별시 종로구 서린동",
+    latitude: 37.5722,
+    longitude: 126.9779,
+  },
+  {
+    placeName: "장소 7",
+    roadAddress: "서울특별시 종로구 인사동",
+    latitude: 37.5729,
+    longitude: 126.9791,
+  },
+  {
+    placeName: "장소 8",
+    roadAddress: "서울특별시 종로구 낙원동",
+    latitude: 37.5735,
+    longitude: 126.9812,
+  },
+  {
+    placeName: "장소 9",
+    roadAddress: "서울특별시 종로구 경운동",
+    latitude: 37.574,
+    longitude: 126.9785,
+  },
+  {
+    placeName: "장소 10",
+    roadAddress: "서울특별시 종로구 삼청동",
+    latitude: 37.5765,
+    longitude: 130.981,
+  },
+];


### PR DESCRIPTION
## PR 제목
[GATE-108] 추천일정 결과 지도 연결

## #️⃣ Issue Number

close #126 

## 📝 요약(Summary)
변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요.

- 추천일정 결과에 지도 연결
- 마커 간 줄 연결하기 (카카오맵 polyline 사용)

## 🛠️ 어떤 변경 사항이 있나요?
변경 사항에 대해 작성해주세요.

- 이전 일정 장소 추가 코드에서 polyline 라이브러리 적용 코드만 추가하였습니다.


## 📸스크린샷 (선
<img width="633" alt="추천일정 결과 지도" src="https://github.com/user-attachments/assets/7a587228-10c0-461d-a97f-c739cb67aaf0">

## 💬 공유사항 to 리뷰어
리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요.

논의해야할 부분이 있다면 적어주세요.
현재는 더미 데이터로 찍은 것이고 api 연동 후에 실제 적용되는걸 봐야할 것 같습니다!
