### PR TITLE
[Feat] 바텀시트 검색목록 UI 수정

### DIFF
--- a/src/interfaces/places/index.ts
+++ b/src/interfaces/places/index.ts
@@ -16,13 +16,14 @@ export interface Place {
   longitude: number;
   roadAddress: string;
   postalCode: string;
+  distance: number;
   favorites: "N" | "Y";
 }
 
 export interface PlanSearchParam {
-  query? : string;
-  cityId : number;
-  category? : string;
+  query?: string;
+  cityId: number;
+  category?: string;
 }
 
 // 맵

--- a/src/pages/place/index.styles.ts
+++ b/src/pages/place/index.styles.ts
@@ -101,7 +101,7 @@ export const modalContent = css`
   top: 0;
   background-color: ${colors.color.White1};
   width: 100%;
-  max-height: 80vh;
+  max-height: 77vh;
   height: 100%;
   padding-top: 2%;
   max-width: 600px;

--- a/src/pages/place/index.styles.ts
+++ b/src/pages/place/index.styles.ts
@@ -39,12 +39,14 @@ export const buttonContainer = ({
   transform: translateX(-50%);
   display: ${isFilterModalOpen ? "none" : "block"};
 
-  background: linear-gradient(
-    to top,
-    ${colors.color.White1},
-    rgba(255, 255, 255, 0.9),
-    rgba(255, 255, 255, 0)
-  );
+  background: ${isModalOpen
+    ? `linear-gradient(
+        to top,
+        ${colors.color.White1},
+        rgba(255, 255, 255, 0.9),
+        rgba(255, 255, 255, 0)
+      )`
+    : "transparent"};
   width: 100%;
   max-width: 600px;
   padding: 30px 0;

--- a/src/pages/place/index.tsx
+++ b/src/pages/place/index.tsx
@@ -45,6 +45,22 @@ export default function Place() {
   const { latitude, longitude } = useLocationStore();
   const navigate = useNavigate();
 
+  const [isFirstOpen, setIsFirstOpen] = useState(true);
+  const [showMessage, setShowMessage] = useState(false);
+
+  useEffect(() => {
+    if (isModalOpen || isFilterModalOpen) {
+      if (isFirstOpen) {
+        setShowMessage(true);
+        setIsFirstOpen(false);
+
+        setTimeout(() => {
+          setShowMessage(false);
+        }, 3000);
+      }
+    }
+  }, [isModalOpen, isFilterModalOpen]);
+
   /** Filter 페이지에서 쿼리스트링으로 넘겨준 필터링값을 받아오기 */
   const { search } = useLocation();
 
@@ -261,6 +277,7 @@ export default function Place() {
   if (isCategoryLoading) {
     return <LoadingBar />;
   }
+
   return (
     <div css={containerStyle}>
       <SearchFilterHeader
@@ -302,6 +319,25 @@ export default function Place() {
             css={modalContent}
             style={filterAnimation}
           >
+            {/* 최초 열림 메시지 */}
+            {showMessage && (
+              <div
+                css={css`
+                  position: absolute;
+                  top: 10px;
+                  left: 50%;
+                  transform: translateX(-50%);
+                  background-color: rgba(0, 0, 0, 0.7);
+                  color: white;
+                  padding: 8px 12px;
+                  border-radius: 8px;
+                  font-size: 14px;
+                  z-index: 999;
+                `}
+              >
+                회색바를 통해 컨텐츠 길이를 조절할 수 있어요!
+              </div>
+            )}
             <div css={modalContent} ref={modalRef}>
               <div
                 css={css`
@@ -344,6 +380,25 @@ export default function Place() {
             style={animation}
             className="checkPlaceBottomTab"
           >
+            {/* 최초 열림 메시지 */}
+            {showMessage && (
+              <div
+                css={css`
+                  position: absolute;
+                  top: 10px;
+                  left: 50%;
+                  transform: translateX(-50%);
+                  background-color: rgba(0, 0, 0, 0.7);
+                  color: white;
+                  padding: 8px 12px;
+                  border-radius: 8px;
+                  font-size: 14px;
+                  z-index: 999;
+                `}
+              >
+                회색바를 통해 컨텐츠 길이를 조절할 수 있어요!
+              </div>
+            )}
             <div css={modalContent} ref={modalRef}>
               <div
                 css={css`
@@ -375,11 +430,7 @@ export default function Place() {
                   onClick={handleTopTab}
                 />
               </div>
-              <ResultPlace
-                places={places}
-                userLatitude={latitude} // 현재 사용자 위치 위도
-                userLongitude={longitude}
-              />
+              <ResultPlace places={places} />
             </div>
           </AnimatedDiv>
         </div>

--- a/src/pages/place/place-detail/components/result-place.styles.ts
+++ b/src/pages/place/place-detail/components/result-place.styles.ts
@@ -29,12 +29,12 @@ export const PlaceItem = css`
 
 export const PlaceImage = css`
   width: 100%;
-  height: 160px;
+  height: 200px;
   object-fit: cover;
 `;
 
 export const PlaceContent = css`
-  padding: 12px;
+  padding: 20px;
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -43,15 +43,43 @@ export const PlaceContent = css`
 export const PlaceName = css`
   font-size: 16px;
   font-weight: bold;
-  color: ${colors.color.Black};
+  color: ${colors.color.Pink};
 `;
 
 export const PlaceAddress = css`
   font-size: 14px;
-  color: ${colors.color.Gray3};
+  color: ${colors.color.Gray1};
 `;
 export const PlaceDistance = css`
+  display: flex;
   font-size: 12px;
-  color: #888;
-  margin-top: 4px;
+  color: ${colors.color.Gray1};
+  margin-left: 15px;
+`;
+
+export const PlaceTags = css`
+  display: flex;
+  font-size: 12px;
+  color: ${colors.color.Gray1};
+  font-weight: 500;
+`;
+
+export const PlaceTextInfo = css`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  margin-top: 5px;
+`;
+
+export const PlaceTop = css`
+  display: flex;
+  flex-direction: row;
+  align-items: baseline;
+`;
+
+export const PlaceCategory = css`
+  display: flex;
+  margin-left: 15px;
+  font-size: 14px;
+  color: ${colors.color.Gray2};
 `;

--- a/src/pages/place/place-detail/components/store-info.tsx
+++ b/src/pages/place/place-detail/components/store-info.tsx
@@ -117,7 +117,11 @@ export default function StoreInfo({
   };
 
   const handleBackButtonClick = () => {
-    navigate(-1);
+    if (storeData?.latitude && storeData?.longitude) {
+      navigate(
+        `/place?latitude=${storeData.latitude}&longitude=${storeData.longitude}`
+      );
+    }
   };
 
   const interpretSizeAvailable = (size: string) => {


### PR DESCRIPTION
## PR 제목
[Feat] 바텀시트 검색목록 UI 수정

## #️⃣ Issue Number

close #177 

## 📝 요약(Summary)
변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요.

- 바텀시트 검색목록 UI 수정
- 거리, 카테고리, 태그 추가

## 🛠️ 어떤 변경 사항이 있나요?
변경 사항에 대해 작성해주세요.

- 장소상세에서 뒤로가기할때 해당 장소로 포커싱
- 지도 탭에서 목록보기 버튼 뒤 그라데이션 삭제

## 📸스크린샷 (선택)
<img width="737" alt="바텀시트 UI" src="https://github.com/user-attachments/assets/c907ca5a-1e3c-420b-a0f5-0919feacd568" />

## 💬 공유사항 to 리뷰어
리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요.

논의해야할 부분이 있다면 적어주세요.
<br/> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
